### PR TITLE
Fixes deploy script to upload via buffer rather than string

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -165,7 +165,7 @@ module.exports = async function () {
         else {
 
           // Get the file's contents.
-          const contents = fs.readFileSync(src, 'utf8');
+          const contents = fs.readFileSync(src);
 
           // For meta, global, and shared content, force the user to confirm before overwriting.
           if( src.indexOf('/_meta/') > -1 || src.indexOf('/_global/') > -1 || src.indexOf('/_shared/') > -1 ) {

--- a/src/engine/__environment__/meta/package.json
+++ b/src/engine/__environment__/meta/package.json
@@ -1,1 +1,1 @@
-/Users/lhamel/Sites/templating-engine/package.json
+../../../../package.json


### PR DESCRIPTION
This fixes the issue with broken images (and other broken asset files) after deploying by uploading via buffer stream rather than trying to read file contents as a string.